### PR TITLE
feat(added args to iso build script)

### DIFF
--- a/build_tools/build_iso.ps1
+++ b/build_tools/build_iso.ps1
@@ -1,19 +1,55 @@
-#INITIALISE VAIRABLES
-# The paths are for inside the container.
-# Things will be mounted to /tmp/rackn
-$offlineDepots = @(
-    "C:/Users/errr/projects/vmware_tools/grd/olb/drpy-agent.zip",
-    "C:/Users/errr/projects/vmware_tools/grd/olb/drpy-firewall.zip",
-    "C:/Users/errr/projects/vmware_tools/grd/olb/VMware-ESXi-7.0.0-15843807-depot.zip"
+<#
+.SYNOPSIS
+    Script to assist with building an ISO with the RackN Components.
+.DESCRIPTION
+    Script to build ISOs with drpy agent embeded.
+.PARAMETER exportpath
+    Full path to where you want the ISO exported. If it does not exist it will
+    be created if it has permssion.
+.PARAMETER imgprofilename
+    Name for the new image profile. This script will add the prefix RKN to what ever name you provide here.
+.PARAMETER offlineDepots
+    A comma seperated list of full paths to the required offline bundles. At least 3 will be required. More are supported.
+.EXAMPLE
+    C:\PS> .\build_iso.ps1 -exportpath c:/temp/isos -imgprofilename Esxi-70-GA-RackN-Agent -depots c:/temp/depots/ESXi-7-depot.zip,c:/temp/depots/RKN-Agent.zip,c:/temp/depots/RKN-Firewall.zip
+.NOTES
+    Author: RackN
+    Date: 06-2020
+#>
+
+param(
+    [Parameter(Mandatory=$true, HelpMessage="Full Path to where you want the ISO exported")]
+    [string]$exportpath,
+    [Parameter(Mandatory=$true, HelpMessage="Name for the new image profile. This script will add the prefix RKN to what ever name you provide here.")]
+    [string]$imgprofilename,
+    [Parameter(Mandatory=$true)]
+    [String[]]$offlineDepots
 )
-$imgprofilename  = "RackN-Agent-Enabled-ISO-7.0GA"
+$imgprofilename = "RKN-$imgprofilename"
+
+if ($offlineDepots.Count -lt 3) {
+    echo "At least 3 depots must be set."
+    echo "1. RackN Firewall"
+    echo "2. RackN Agent"
+    echo "3. ESXi Depot"
+    echo "Additional are supported, but at least 3 will be needed for the build to work."
+    echo "Ex: -depots c:/temp/RKN-DRPY-Agent.zip,c:/temp/RKN-FW-RULE.zip,c:/temp/ESXi-olb.zip"
+    exit
+}
+
+## This should be edited
+#$exportpath = "C:/Users/errr/projects/vmware_tools/grd"
+
+
 
 #OPTIONS
 $withtools = $false #use profile with VMtools or not
 $exportiso = $true #export iso
 $securityonly = $false #security only profiles
-$exportpath = "C:/Users/errr/projects/vmware_tools/grd"
 
+If(!(test-path $exportpath)) {
+      New-Item -ItemType Directory -Force -Path $exportpath
+}
 #SCRIPT
 #clean the decks
 Get-EsxSoftwareDepot | Remove-EsxSoftwareDepot
@@ -27,10 +63,10 @@ $baseprofile = Get-EsxImageProfile | select * | Out-GridView -PassThru
 #create the image profile
 #this is a grouping of all the vibs for the install
 #clone a profile from the vendor image as a base to work from
-New-EsxImageProfile -CloneProfile $baseprofile.Name -Name $imgprofilename -Vendor $baseprofile.vendor -AcceptanceLevel CommunitySupported
+New-EsxImageProfile -CloneProfile $baseprofile.Name -Name $imgprofilename -Vendor $baseprofile.vendor
 #add in the DRPY Agent
-Add-EsxSoftwarePackage -ImageProfile $imgprofilename -SoftwarePackage DRP-Firewall-Rule -Force
-Add-EsxSoftwarePackage -ImageProfile $imgprofilename -SoftwarePackage DRP-Agent -Force
+Add-EsxSoftwarePackage -ImageProfile $imgprofilename -SoftwarePackage DRP-Firewall-Rule
+Add-EsxSoftwarePackage -ImageProfile $imgprofilename -SoftwarePackage DRP-Agent
 
 if ($withtools -eq $true) {
     $toolsFilter = "-standard"
@@ -66,9 +102,9 @@ $allImageProfiles | % {
         }
     }
 }
-Set-EsxImageProfile -AcceptanceLevel CommunitySupported -ImageProfile $imgprofilename
+Set-EsxImageProfile -ImageProfile $imgprofilename
 #Export ISO + Bundle
-Export-EsxImageProfile -ImageProfile $imgprofilename -ExportToBundle -FilePath $($exportpath + "/" + $imgprofilename + ".zip") -Force
+Export-EsxImageProfile -ImageProfile $imgprofilename -ExportToBundle -FilePath $($exportpath + "/" + $imgprofilename + ".zip")
 if ($exportiso -eq $true) {
-    Export-EsxImageProfile -ImageProfile $imgprofilename -ExportToISO -FilePath $($exportpath + "/" + $imgprofilename + ".iso") -Force
+    Export-EsxImageProfile -ImageProfile $imgprofilename -ExportToISO -FilePath $($exportpath + "/" + $imgprofilename + ".iso")
 }


### PR DESCRIPTION
Removed all hard coded paths and replaced with arcg based solution

Example usage:

    .\build_iso.ps1 -exportpath C:\Users\errr\projects\vmware_tools\grd -imgprofilename RackN-Esxi-7.0-DellEMC-A00 -offlineDepots C:\RKN-DRPY-Agent_1.0-0.0.0001_16333135.zip,C:\RKN-DRPY-FW-RULE_1.0-0.0.0003_16333171.zip,C:\VMware-VMvisor-Installer-7.0.0-15843807.x86_64-DellEMC_Customized-A00.zip

Signed-off-by: Michael Rice <michael@michaelrice.org>